### PR TITLE
fix npm start (typescript static version fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ncp": "^2.0.0",
     "rimraf": "^2.5.2",
     "tslint": "^3.11.0",
-    "typescript": "2.0.0"
+    "typescript": "^2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm start` doesn't works. The reason was typescript version which was too low for some additional node libraries.
Fixed static typescript version 2.0.0 -> ^2.0.0. 